### PR TITLE
Fix cypress readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Ensures all parallel jobs finish work at a similar time!
 | ============= |  3  | 26 minutes |
 
 - [Jest documentation](packages/jest/README.md)
-- [Cypress documentation](packages/jest/README.md)
+- [Cypress documentation](packages/cypress/README.md)


### PR DESCRIPTION
The cypress readme link in the /README.md was wrong wrong.