### PR TITLE
Fix missing testsuites in junit breaking split.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 .bob
 dist

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -22,14 +22,18 @@ function loadReports(config: any): TimeReport[] {
   const rootDir = config.projectRoot;
   const reports = glob.sync(pattern, { cwd: rootDir, absolute: true });
 
-  return reports.map(loadReport).map((t) => ({
+  return reports.map(loadReport).filter(t => !!t).map((t) => ({
     time: t.time,
     path: path.join(config.projectRoot, t.path),
   }));
 }
 
-function loadReport(file: string) {
+function loadReport(file: string): null | {time: number, path: string} {
   const junit = loadXML(file);
+
+  if (!junit.testsuites.testsuite || !junit.testsuites.testsuite.length) {
+    return null;
+  }
 
   const time = parseFloat(junit.testsuites.time);
   const testfile = findFilenameInJUnit(junit.testsuites);


### PR DESCRIPTION
I have encountered a case where a junit xml is generated in the following manner:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" time="0.0000" tests="0" failures="0">
</testsuites>
```
This PR adds additional checks to not break the split when encountering this format.