### PR TITLE
Update references in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Install
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Install
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Install
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release Pull Request or Publish packages
-        uses: changesets/action@master
+        uses: changesets/action@main
         with:
           publish: yarn release
           commit: 'chore(release): update monorepo packages versions'


### PR DESCRIPTION
💁 These changes update some old GitHub Actions references in the existing workflows:
* `actions/setup-node`: use the `v2` tag across both workflows
* `changesets/action`: use `main` instead of `master` for the branch reference